### PR TITLE
Add Realm roles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,30 @@
 
 Django Keycloak Auth is a simple library that authorizes your application's resources using Django Rest Framework.
 
-This package is used to perform authorization by keycloak roles.
+This package is used to perform authorization by keycloak roles from JWT token. Both realm roles and client roles are
+supported.
+
+For example, the following token indicates that the user has the realm role "manager" and the client
+roles "director" and "employer" :
+
+```
+...
+
+  "realm_access": {
+    "roles": [
+      "manager"
+    ]
+  },
+  "resource_access": {
+    "first-api": {
+      "roles": [
+        "director",
+        "employer",
+      ]
+    }
+  },
+  ...
+```
 
 For review see https://github.com/marcelo225/django-keycloak-auth
 

--- a/django-keycloak-auth/middleware.py
+++ b/django-keycloak-auth/middleware.py
@@ -105,7 +105,8 @@ class KeycloakMiddleware:
         token_roles = self.keycloak.roles_from_token(token)
         if token_roles is None:
             return JsonResponse(
-                {'detail': 'This token has no client_id roles or client_id has not configured correctly.'}, 
+                {'detail': 'This token has no client_id roles and no realm roles or client_id is not configured '
+                           'correctly.'},
                 status=AuthenticationFailed.status_code
             )
         

--- a/django-keycloak-auth/tests.py
+++ b/django-keycloak-auth/tests.py
@@ -5,11 +5,12 @@ from .middleware import KeycloakMiddleware, KeycloakConnect
 from core import views
 from unittest.mock import Mock
 
+
 class KeycloakMiddlewareTestCase(TestCase):
 
     # Fixture prerequisites to run the tests
     # fixtures = ['banks']
-    
+
     def setUp(self):
         self.uri = '/core/banks'
         self.client = Client()
@@ -21,9 +22,8 @@ class KeycloakMiddlewareTestCase(TestCase):
         settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'] = 'REALM'
         settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'] = 'client-backend'
         settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_SECRET_KEY'] = '41ab4e22-a6f3-4bef-86e3-f2a1c97d6387'
-    
+
     def test_when_has_not_some_keycloak_configuration_settings(self):
-        
         # GIVEN doesn't configurated keycloak django settings
         del settings.KEYCLOAK_CONFIG['KEYCLOAK_SERVER_URL']
 
@@ -32,9 +32,8 @@ class KeycloakMiddlewareTestCase(TestCase):
         with self.assertRaises(Exception):
             response = self.client.get(self.uri)
             KeycloakMiddleware(Mock)(self.request)
-    
+
     def test_when_has_not_keycloak_server_url_configuration_settings(self):
-        
         # GIVEN None value KEYCLOAK_SERVER_URL django settings
         settings.KEYCLOAK_CONFIG['KEYCLOAK_SERVER_URL'] = None
 
@@ -45,7 +44,6 @@ class KeycloakMiddlewareTestCase(TestCase):
             KeycloakMiddleware(Mock)(self.request)
 
     def test_when_has_not_keycloak_realm_configuration_settings(self):
-        
         # GIVEN None value KEYCLOAK_REALM django settings
         settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'] = None
 
@@ -54,9 +52,8 @@ class KeycloakMiddlewareTestCase(TestCase):
         with self.assertRaises(Exception):
             response = self.client.get(self.uri)
             KeycloakMiddleware(Mock)(self.request)
-    
+
     def test_when_has_not_keycloak_client_secret_key_configuration_settings(self):
-        
         # GIVEN None value KEYCLOAK_CLIENT_SECRET_KEY django settings
         settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_SECRET_KEY'] = None
 
@@ -65,9 +62,8 @@ class KeycloakMiddlewareTestCase(TestCase):
         with self.assertRaises(Exception):
             response = self.client.get(self.uri)
             KeycloakMiddleware(Mock)(self.request)
-    
+
     def test_when_has_not_keycloak_client_id_configuration_settings(self):
-        
         # GIVEN None value KEYCLOAK_CLIENT_ID django settings
         settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'] = None
 
@@ -76,9 +72,8 @@ class KeycloakMiddlewareTestCase(TestCase):
         with self.assertRaises(Exception):
             response = self.client.get(self.uri)
             KeycloakMiddleware(Mock)(self.request)
-    
+
     def test_when_some_URI_is_permitted_on_authentication_with_keycloak_roles_on_view(self):
-        
         # GIVEN that a URL has been given that it will fire without authorization
         settings.KEYCLOAK_EXEMPT_URIS = ['core/banks']
 
@@ -87,9 +82,8 @@ class KeycloakMiddlewareTestCase(TestCase):
 
         # THEN allows endpoint to be accessed
         self.assertEquals(response.status_code, status.HTTP_200_OK)
-    
+
     def test_when_some_URI_is_permitted_on_authentication_without_keycloak_roles_attribute_on_view(self):
-        
         # GIVEN i've got a URI without 'keycloak_roles' on the View
         uri_no_roles = '/core/cars'
 
@@ -98,19 +92,18 @@ class KeycloakMiddlewareTestCase(TestCase):
 
         # THEN allows endpoint to be accessed
         self.assertEquals(response.status_code, status.HTTP_200_OK)
-    
-    def test_when_some_URI_without_authorization_on_http_header(self):
 
+    def test_when_some_URI_without_authorization_on_http_header(self):
         # GIVEN a View endpoint
-        view = views.BankViewSet.as_view({'get': 'list'})        
-        
+        view = views.BankViewSet.as_view({'get': 'list'})
+
         # WHEN makes GET request without HTTP_AUTHORIZATIOND
         request = self.factory.get(self.uri)
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
-                
+
         # THEN not allows endpoint to be accessed (401)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
-    
+
     def test_when_token_not_active(self):
         # GIVEN token as not valid
         KeycloakConnect.is_token_active = Mock(return_value=False)
@@ -121,13 +114,13 @@ class KeycloakMiddlewareTestCase(TestCase):
         # GIVEN a fake request
         request = self.factory.get(self.uri)
         request.META['HTTP_AUTHORIZATION'] = 'Bearer token'
-        
+
         # WHEN middleware is processed
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
-                
+
         # THEN not allows endpoint to be accessed (401)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
-    
+
     def test_when_token_as_active_and_no_roles_request_not_authorizated(self):
         # GIVEN token as valid
         KeycloakConnect.is_token_active = Mock(return_value=True)
@@ -140,14 +133,14 @@ class KeycloakMiddlewareTestCase(TestCase):
 
         # GIVEN a fake request
         request = self.factory.get(self.uri)
-        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'       
-        
+        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'
+
         # WHEN middleware is processed
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
-                
+
         # THEN not allows endpoint to be accessed (401)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
-    
+
     def test_when_token_as_active_and_has_roles_request_not_authorizated(self):
         # GIVEN token as valid
         KeycloakConnect.is_token_active = Mock(return_value=True)
@@ -161,11 +154,11 @@ class KeycloakMiddlewareTestCase(TestCase):
 
         # GIVEN a fake request
         request = self.factory.get(self.uri)
-        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'       
-        
+        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'
+
         # WHEN middleware is processed
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
-        
+
         # THEN does't allow endpoint authorization
         self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -182,10 +175,80 @@ class KeycloakMiddlewareTestCase(TestCase):
 
         # GIVEN a fake request
         request = self.factory.get(self.uri)
-        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'       
-        
+        request.META['HTTP_AUTHORIZATION'] = 'Bearer token_fake'
+
         # WHEN middleware is processed
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
-        
+
         # THEN allows endpoint and pass token roles to request View
         self.assertEquals(['director'], request.roles)
+
+    def test_when_realm_roles_and_client_roles_are_present_both_are_returned(self):
+        fake_token = {
+            "realm_access": {
+                "roles": [
+                    "director",
+                ]
+            },
+            "resource_access": {
+                settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID']: {
+                    "roles": [
+                        "judge"
+                    ]
+                }
+            }}
+
+        keycloak = KeycloakConnect(settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'])
+        keycloak.introspect = Mock(return_value=fake_token)
+        roles = keycloak.roles_from_token(Mock())
+
+        self.assertEquals(['judge', 'director'], roles)
+
+    def test_when_only_realm_roles_are_present_realm_roles_are_returned(self):
+        fake_token = {
+            "realm_access": {
+                "roles": [
+                    "director",
+                ]
+            },
+        }
+
+        keycloak = KeycloakConnect(settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'])
+        keycloak.introspect = Mock(return_value=fake_token)
+        roles = keycloak.roles_from_token(Mock())
+
+        self.assertEquals(['director'], roles)
+
+    def test_when_only_client_roles_are_present_client_roles_are_returned(self):
+        fake_token = {
+            "resource_access": {
+                settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID']: {
+                    "roles": [
+                        "judge"
+                    ]
+                }
+            }
+        }
+
+        keycloak = KeycloakConnect(settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'])
+        keycloak.introspect = Mock(return_value=fake_token)
+        roles = keycloak.roles_from_token(Mock())
+
+        self.assertEquals(['judge'], roles)
+
+    def test_when_no_role_is_present_none_is_returned(self):
+        fake_token = {}
+
+        keycloak = KeycloakConnect(settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_REALM'],
+                                   settings.KEYCLOAK_CONFIG['KEYCLOAK_CLIENT_ID'])
+        keycloak.introspect = Mock(return_value=fake_token)
+        roles = keycloak.roles_from_token(Mock())
+
+        self.assertEquals(None, roles)


### PR DESCRIPTION
This pull request adds support for Realm Roles in addition to already supported client roles. It also adds some None safety checks to the roles retrieval process and various PEP compliant reformatting along the way. Tests related to the new feature are included.