### PR TITLE
feat: updated setup requirements for requests to allow latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="django-keycloak-auth",
-    version="0.9.3",
+    version="0.9.4",
     packages=find_packages(),
 
     # Project uses reStructuredText, so ensure that the docutils get
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "Django",
         "djangorestframework>=3.10.0",
-        "requests==2.24.0"
+        "requests>=2.24.0"
     ],
 
     # metadata to display on PyPI


### PR DESCRIPTION
Rigid requests dependency causes conflicts with other packages since the latest version is 2.26.0 for requests. Modifying it allows using the latest version