### PR TITLE
Bugfix: Fix exempt URI method views

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ $ python -m pip install --upgrade -r requirements.txt
 $ python setup.py sdist
 
 # Generate a local dist (verify version)
-$ pip install dist/django-keycloak-auth-0.9.7.tar.gz
+$ pip install dist/*
 
 # Create migrations, fixtures and run django server
 $ python manage.py makemigrations && \

--- a/core/views.py
+++ b/core/views.py
@@ -14,7 +14,6 @@ class BankViewSet(viewsets.ModelViewSet):
     queryset = models.Bank.objects.all()    
     keycloak_roles = {
         'GET': ['director', 'judge', 'employee'],
-        'POST': ['director', 'judge', ],
         'UPDATE': ['director', 'judge', ],
         'DELETE': ['director', 'judge', ],
         'PATCH': ['director', 'judge', 'employee'],

--- a/django_keycloak_auth/middleware.py
+++ b/django_keycloak_auth/middleware.py
@@ -88,8 +88,11 @@ class KeycloakMiddleware:
 
         # There's condictions for these view_func.cls:
         # 1) @api_view -> view_func.cls is WrappedAPIView (validates in 'keycloak_roles' in decorators.py) -> True
-        # 2) When it is a APIView, ViewSet or ModelViewSet with 'keycloak_roles' attribute -> False        
-        is_api_view = True if str(view_func.cls.__qualname__) == "WrappedAPIView" else False
+        # 2) When it is a APIView, ViewSet or ModelViewSet with 'keycloak_roles' attribute -> False
+        try:
+            is_api_view = True if str(view_func.cls.__qualname__) == "WrappedAPIView" else False
+        except AttributeError:
+            is_api_view = False
 
         # Read if View has attribute 'keycloak_roles' (for APIView, ViewSet or ModelViewSet)
         # Whether View hasn't this attribute, it means all request method routes will be permitted.        

--- a/django_keycloak_auth/middleware.py
+++ b/django_keycloak_auth/middleware.py
@@ -82,7 +82,9 @@ class KeycloakMiddleware:
         if hasattr(settings, 'KEYCLOAK_EXEMPT_URIS'):
             path = request.path_info.lstrip('/')
             if any(re.match(m, path) for m in settings.KEYCLOAK_EXEMPT_URIS):
-                return None
+                # Checks to see if a request.method explicitly overwrites exemptions in SETTINGS
+                if hasattr(view_func.cls, "keycloak_roles") and request.method not in view_func.cls.keycloak_roles:
+                    return None
 
         # There's condictions for these view_func.cls:
         # 1) @api_view -> view_func.cls is WrappedAPIView (validates in 'keycloak_roles' in decorators.py) -> True

--- a/django_keycloak_auth/tests.py
+++ b/django_keycloak_auth/tests.py
@@ -101,7 +101,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = self.client.get(self.uri)
 
         # THEN allows endpoint to be accessed
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_when_some_URI_is_permitted_on_authentication_without_keycloak_roles_attribute_on_view(self):
         # GIVEN i've got a URI without 'keycloak_roles' on the View
@@ -111,7 +111,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = self.client.get(uri_no_roles)
 
         # THEN allows endpoint to be accessed
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_when_some_URI_without_authorization_on_http_header(self):
         # GIVEN a View endpoint
@@ -122,7 +122,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})        
 
         # THEN not allows endpoint to be accessed (401)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_when_token_not_active(self):
         # GIVEN token as not valid
@@ -139,7 +139,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN not allows endpoint to be accessed (401)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_when_token_as_active_and_no_roles_request_not_authorizated(self):
         # GIVEN token as valid
@@ -159,7 +159,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN not allows endpoint to be accessed (401)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_when_token_as_active_and_has_roles_request_not_authorizated(self):
         # GIVEN token as valid
@@ -180,7 +180,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN does't allow endpoint authorization
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_when_token_as_active_and_has_roles_request_authorizated(self):
         # GIVEN token as valid
@@ -201,7 +201,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN allows endpoint and pass token roles to request View
-        self.assertEquals(['director'], request.roles)
+        self.assertEqual(['director'], request.roles)
 
     def test_when_realm_roles_and_client_roles_are_present_both_are_returned(self):
         fake_token = {
@@ -221,7 +221,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         self.keycloak.userinfo = Mock(return_value=fake_token)
         roles = self.keycloak.roles_from_token(Mock())
 
-        self.assertEquals(['judge', 'director'], roles)
+        self.assertEqual(['judge', 'director'], roles)
 
     def test_when_only_realm_roles_are_present_realm_roles_are_returned(self):
         fake_token = {
@@ -235,7 +235,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         self.keycloak.userinfo = Mock(return_value=fake_token)
         roles = self.keycloak.roles_from_token(Mock())
 
-        self.assertEquals(['director'], roles)
+        self.assertEqual(['director'], roles)
 
     def test_when_only_client_roles_are_present_client_roles_are_returned(self):
         fake_token = {
@@ -251,7 +251,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         self.keycloak.userinfo = Mock(return_value=fake_token)
         roles = self.keycloak.roles_from_token(Mock())
 
-        self.assertEquals(['judge'], roles)
+        self.assertEqual(['judge'], roles)
 
     def test_when_no_role_is_present_none_is_returned(self):
         fake_token = {}
@@ -259,7 +259,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         self.keycloak.userinfo = Mock(return_value=fake_token)
         roles = self.keycloak.roles_from_token(Mock())
 
-        self.assertEquals(None, roles)
+        self.assertEqual(None, roles)
     
     def test_when_only_user_info_is_present_user_info_are_returned(self):
         fake_token = {
@@ -272,7 +272,7 @@ class KeycloakMiddlewareTestCase(TestCase):
         
         userinfo = self.keycloak.userinfo(Mock())
         
-        self.assertEquals(fake_token['sub'], userinfo['sub'])
+        self.assertEqual(fake_token['sub'], userinfo['sub'])
 
     def test_keycloak_connect_well_known(self):
         """Test keycloak endpoint well_known when status >= 400"""        
@@ -334,7 +334,7 @@ class KeycloakRolesDecoratorTestCase(TestCase):
         response = KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN not allows endpoint to be accessed (401)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_when_token_is_active_and_has_roles_request_authorizated(self):
         
@@ -358,4 +358,4 @@ class KeycloakRolesDecoratorTestCase(TestCase):
         KeycloakMiddleware(Mock()).process_view(request, view, [], {})
 
         # THEN allows endpoint and pass token roles and userinfo to request View
-        self.assertEquals(['director'], request.roles)
+        self.assertEqual(['director'], request.roles)

--- a/django_keycloak_auth/tests.py
+++ b/django_keycloak_auth/tests.py
@@ -98,10 +98,12 @@ class KeycloakMiddlewareTestCase(TestCase):
         settings.KEYCLOAK_EXEMPT_URIS = ['core/banks']
 
         # WHEN makes a request that has 'keycloak_roles' attribute on View
-        response = self.client.get(self.uri)
+        get_response = self.client.get(self.uri)
+        post_response = self.client.post(self.uri, {"name": "fake", "code": "test"})
 
         # THEN allows endpoint to be accessed
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(get_response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(post_response.status_code, status.HTTP_201_CREATED)
 
     def test_when_some_URI_is_permitted_on_authentication_without_keycloak_roles_attribute_on_view(self):
         # GIVEN i've got a URI without 'keycloak_roles' on the View

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,18 @@
 version: "3"
 
-volumes:
-  my_data:
-
 networks:
   my_network:
     driver: bridge
 
 services:
-  db:
-    image: postgres:12.0-alpine
-    volumes:
-      - my_data:/var/lib/postgresql/data
+  keycloak:
+    image: jboss/keycloak    
+    restart: "no"
     environment:
-      POSTGRES_DB: deposito
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: 123
+      - DB_VENDOR=H2      
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=123
+    ports:
+      - "8080:8080"
     networks:
       - my_network
-
-  keycloak:
-      image: jboss/keycloak
-      environment:
-        DB_VENDOR: POSTGRES
-        DB_ADDR: db
-        DB_DATABASE: deposito
-        DB_USER: admin
-        DB_SCHEMA: public
-        DB_PASSWORD: 123
-        KEYCLOAK_USER: admin
-        KEYCLOAK_PASSWORD: 123
-      ports:
-        - 8080:8080
-      depends_on:
-        - db
-      networks:
-        - my_network

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="django-keycloak-auth",
-    version="0.9.7",
+    version="0.9.8",
     packages=find_packages(),
 
     # Project uses reStructuredText, so ensure that the docutils get


### PR DESCRIPTION
This Pull Request is a response to #27.

This corrects some testing logic loopholes that just happened to have passed, before. There are still issues with the tests, but these corrections allow for my use-cases to become unblocked.

The important part of this PR is the addition of a new `if` statement:

```python
    def process_view(self, request, view_func, view_args, view_kwargs):
        
        # for now there is no role assigned yet and no userinfo defined
        request.roles = []
        request.userinfo = []

        # Checks the URIs (paths) that doesn't needs authentication        
        if hasattr(settings, 'KEYCLOAK_EXEMPT_URIS'):
            path = request.path_info.lstrip('/')
            if any(re.match(m, path) for m in settings.KEYCLOAK_EXEMPT_URIS):
                # Checks to see if a request.method explicitly overwrites exemptions in SETTINGS
                if hasattr(view_func.cls, "keycloak_roles") and request.method not in view_func.cls.keycloak_roles:
                    return None
```

Specific line:

```python
if hasattr(view_func.cls, "keycloak_roles") and request.method not in view_func.cls.keycloak_roles:
```

This logic checks to see if a `request.method` explicitly overwrites exemptions in `SETTINGS.KEYCLOAK_EXEMPT_URIS`. Adding one more check to see if the processing of a given view should occur makes it simple to allow for more complex behaviors on a `ModelViewSet` than either fully exempted or not.